### PR TITLE
Gracefully close client connection, bump version number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Limitations
 
 Known Problems
 --------------
-- Occasional segmentation faults after disconnect of a client
+- Hopefully none ;-)
 
 Building
 -------


### PR DESCRIPTION
I believe this change will fix the Known Problem: Occasional segmentation faults after disconnect of a client
Also make sure `rtlsdr_cancel_async` completes before prodeecing with new connection.
Bumped the version to indicate changes.